### PR TITLE
Only add path from RMVIEW_CONF if it exists (fixes #3)

### DIFF
--- a/src/rmview.py
+++ b/src/rmview.py
@@ -34,7 +34,10 @@ class rMViewApp(QApplication):
   def __init__(self, args):
     super(rMViewApp, self).__init__(args)
     config_files = [] if len(args) < 2 else [args[1]]
-    config_files += ['rmview.json', os.environ.get("RMVIEW_CONF")]
+    config_files += ['rmview.json']
+    rmview_conf = os.environ.get("RMVIEW_CONF") 
+    if rmview_conf is not None:
+        config_files += [rmview_conf]
     log.info("Searching configuration in " + ', '.join(config_files))
     for f in config_files:
       try:


### PR DESCRIPTION
This fixes #3 by only adding the value of `os.environ.get("RMVIEW_CONF")` to the list if it is not `None`.