### PR TITLE
Pen pointer improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ The supported configuration settings are:
   "pen_color": "red",
   "pen_trail": 1000, // set to 0 to disable, default: 200
   "background_color": "black", // default: white
-  "fetch_frame_delay": 0.03 // sleep 0.03s on remarkable before fetching new frame (default is no delay)
-  "lz4_path_on_remarkable": "/usr/opt/lz4" // default: $HOME/lz4
+  "fetch_frame_delay": 0.03, // sleep 0.03s on remarkable before fetching new frame (default is no delay)
+  "lz4_path_on_remarkable": "/usr/opt/lz4", // default: $HOME/lz4
+  "hide_pen_on_press": false // hides pointer when pen touches display, default: true
 }
 ```
 

--- a/src/rmview.py
+++ b/src/rmview.py
@@ -185,7 +185,8 @@ class rMViewApp(QApplication):
     self.pen.setZValue(100)
     self.penworker.signals.onPenMove.connect(self.movePen)
     self.penworker.signals.onPenLift.connect(self.showPen)
-    self.penworker.signals.onPenPress.connect(self.hidePen)
+    if self.config.get("hide_pen_on_press", True):
+        self.penworker.signals.onPenPress.connect(self.hidePen)
     self.penworker.signals.onPenNear.connect(self.showPen)
     self.penworker.signals.onPenFar.connect(self.hidePen)
 


### PR DESCRIPTION
When placing the pen pointer, the pen radius is now taken into account.

With this change, I have noticed that it is much more pleasant to always have the pointer be displayed on the screen when writing and staring at the screen, so I added an option for that. It defaults to the previous behavior.