### PR TITLE
Optionally Install Remarkable VNC files if not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,16 +62,17 @@ The supported configuration settings are below.
 Look in file `example.json` for an example configuration.
 All the settings are optional.
 
-| Setting key              | Values                                                  | Default       |
-| ------------------------ | ------------------------------------------------------- | ------------- |
-| `ssh`                    | Connection parameters (see below)                       | `{}`          |
-| `orientation`            | `"landscape"`, `"portrait"`, `"auto"`                   | `"landscape"` |
-| `pen_size`               | diameter of pointer in px                               | `15`          |
-| `pen_color`              | color of pointer and trail                              | `"red"`       |
-| `pen_trail`              | persistence of trail in ms                              | `200`         |
-| `background_color`       | color of window                                         | `"white"`     |
-| `hide_pen_on_press`      | if true, the pointer is hidden while writing            | `true`        |
-
+| Setting key              | Values                                                                     | Default       |
+| ------------------------ | -------------------------------------------------------------------------- | ------------- |
+| `ssh`                    | Connection parameters (see below)                                          | `{}`          |
+| `orientation`            | `"landscape"`, `"portrait"`, `"auto"`                                      | `"landscape"` |
+| `pen_size`               | diameter of pointer in px                                                  | `15`          |
+| `pen_color`              | color of pointer and trail                                                 | `"red"`       |
+| `pen_trail`              | persistence of trail in ms                                                 | `200`         |
+| `background_color`       | color of window                                                            | `"white"`     |
+| `hide_pen_on_press`      | if true, the pointer is hidden while writing                               | `true`        |
+| `auto_install`           | if true, attempt to download vnc client if not present (requires internet) | `false`       |
+| `bypass_kmod_checksum`   | bypass checksum of kernel module on Remarkable before loading              | `false`       |
 
 Connection parameters are provided as a dictionary with the following keys (all optional):
 

--- a/src/rmview/installparams.py
+++ b/src/rmview/installparams.py
@@ -1,0 +1,5 @@
+kernel_mod_url = "https://github.com/peter-sa/mxc_epdc_fb_damage/releases/download/v0.0.1/mxc_epdc_fb_damage.ko"
+kernel_mod_hash = 'c76469dcb1674e7ee86bf534b39a64ead2872da1'
+
+vncserver_url = "https://github.com/peter-sa/rM-vnc-server/releases/download/v0.0.1/rM-vnc-server"
+vncserver_hash = '8aebbe149190101de2cb6983648341458c2d61a8'

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -173,7 +173,11 @@ class rMViewApp(QApplication):
   def connected(self, ssh):
     self.ssh = ssh
     self.viewer.setWindowTitle("rMview - " + self.config.get('ssh').get('address'))
-    self.fbworker = FrameBufferWorker(ssh, delay=self.config.get('fetch_frame_delay'))
+    self.fbworker = FrameBufferWorker(ssh,
+      auto_install=self.config.get('auto_install'),
+      bypass_kmod_checksum=self.config.get('bypass_kmod_checksum'),
+      delay=self.config.get('fetch_frame_delay'),
+      )
     self.fbworker.signals.onNewFrame.connect(self.onNewFrame)
     self.fbworker.signals.onFatalError.connect(self.frameError)
     self.threadpool.start(self.fbworker)

--- a/src/rmview/workers.py
+++ b/src/rmview/workers.py
@@ -129,6 +129,14 @@ class FrameBufferWorker(QRunnable):
         
       # Should we always checksum this kernel module before attempting to load?
       # An incomplete wget will leave some partial file around
+      _,out,_ = self.ssh.exec_command("cat /proc/cpuinfo")
+      log.debug("Cat returned %d", out.channel.recv_exit_status())
+      cpuinfo = out.read().decode("utf-8").split("\n")[10]
+
+      # Make sure this is a Remarkable V1 before attempting to load the kernel module
+      if not 'Freescale i.MX6 SoloLite' in cpuinfo:
+        raise RuntimeError("Unexpected processor. Is this a Remarkable v1?")
+
       _,out,_ = self.ssh.exec_command("/sbin/insmod $HOME/mxc_epdc_fb_damage.ko")
       log.debug("Insmod returned %d", out.channel.recv_exit_status())
       _,_,out = self.ssh.exec_command("$HOME/rM-vnc-server")


### PR DESCRIPTION
This implements #12  ( Close #12 )

- If `auto_install` configuration is true, wget and checksum `mxc_epdc_fb_damage` and `rM-vnc-server` if not present
- Check `/proc/cpuinfo` to ensure tablet is a Remarkable V1 before attempting the kernel module load
- Checksum kernel module before loading (bypassable with `kmod_checksum_bypass`)