### PR TITLE
Add dockerfile and run script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.9-slim-buster
+RUN apt-get update
+RUN apt-get install -y \
+  libdbus-1-3 \
+  libfontconfig \
+  libgl1-mesa-glx \
+  libglib2.0-0 \
+  libxcb-icccm4 \
+  libxcb-image0 \
+  libxkbcommon-x11-0
+RUN apt-get clean
+WORKDIR /rmview
+COPY resources.qrc setup.cfg setup.py ./
+COPY assets ./assets
+COPY bin ./bin
+COPY src ./src
+RUN pip install --upgrade pip
+# TODO: setup.py could to be fixed to include install_requires
+#       see also: https://stackoverflow.com/q/21915469/543875
+RUN pip install pyqt5==5.14.2 paramiko twisted
+RUN pip install .[tunnel]
+RUN pip cache purge
+CMD rmview

--- a/README.md
+++ b/README.md
@@ -72,6 +72,12 @@ On the reMarkable itself you need to install [rM-vnc-server][vnc] by copying the
 
 Then you can run the program with `python -m rmview`.
 
+### Using Docker
+
+This project contains a `Dockerfile` so that `rmview` and all its dependencies can be installed and run inside a Docker container.
+Since `rmview` not only reads your local configuration but also needs an X11 display, you should run `docker-run.sh` which takes care of the host mappings.
+Please note that `docker-run.sh` is written for Unix-like OSes and expects your rmview configuration inside your local `$HOME/.config/rmview/` folder.
+
 ## Usage and configuration
 
 **Suggested first use:**

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+CONFIG_DIR=$HOME/.config/rmview
+mkdir -p $CONFIG_DIR
+xhost local:root
+docker build -t rmview .
+docker run \
+  --env DISPLAY=$DISPLAY \
+  --network host \
+  --volume $CONFIG_DIR:/root/.config \
+  --volume /tmp/.X11-unix:/tmp/.X11-unix \
+  rmview


### PR DESCRIPTION
This MR introduces a `Dockerfile` and a run script to facilitate running `rmview` in a Docker container. This is interesting for Docker users as it avoids installing any other requirements (besides Docker) on your host system. The MR adds a section to the README.md file for installing and running `rmview` with Docker.