### PR TITLE
do not garbage collect cloned frames and create them with the correct rotation

### DIFF
--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -41,6 +41,8 @@ class rMViewApp(QApplication):
   pen_size = 15
   trail = None  # None: disabled, False: inactive, True: active
 
+  cloned_frames = []
+
   def __init__(self, args):
     super(rMViewApp, self).__init__(args)
 
@@ -425,6 +427,8 @@ class rMViewApp(QApplication):
     v = QtImageViewer()
     v.setImage(img)
     v.show()
+    v.rotate(self.viewer._rotation)
+    self.cloned_frames.append(v)
 
   @pyqtSlot()
   def toggleStreaming(self):

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -41,7 +41,7 @@ class rMViewApp(QApplication):
   pen_size = 15
   trail = None  # None: disabled, False: inactive, True: active
 
-  cloned_frames = []
+  cloned_frames = set()
 
   def __init__(self, args):
     super(rMViewApp, self).__init__(args)
@@ -425,10 +425,12 @@ class rMViewApp(QApplication):
     img = QPixmap.fromImage(img)
     img.detach()
     v = QtImageViewer()
+    v.setAttribute(Qt.WA_DeleteOnClose)
     v.setImage(img)
     v.show()
     v.rotate(self.viewer._rotation)
-    self.cloned_frames.append(v)
+    self.cloned_frames.add(v)
+    v.destroyed.connect(lambda: self.cloned_frames.discard(v))
 
   @pyqtSlot()
   def toggleStreaming(self):


### PR DESCRIPTION
fixes #61 

The problem was that the variable `v` had no owner after the end of the function which caused the garbage collector to eat it.
Also I found that the frames were not created with the correct rotation.

