### PR TITLE
Add option to invert colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ All the settings are optional.
 | `pen_color`              | color of pointer and trail                              | `"red"`       |
 | `pen_trail`              | persistence of trail in ms                              | `200`         |
 | `background_color`       | color of window                                         | `"white"`     |
+| `invert_colors`          | if true, start the tablet with inverted colors          | `false`       |
 | `hide_pen_on_press`      | if true, the pointer is hidden while writing            | `true`        |
 | `show_pen_on_lift`       | if true, the pointer is shown when lifting the pen      | `true`        |
 | `forward_mouse_events`   | Send mouse events to tablet (see below)                 | `false`       |

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -92,6 +92,9 @@ class rMViewApp(QApplication):
     if 'background_color' in self.config:
       self.viewer.setBackgroundBrush(QBrush(QColor(self.config.get('background_color'))))
 
+    if self.config.get('invert_colors'):
+        self.viewer.invert_colors()
+
     ### ACTIONS
     self.cloneAction = QAction('Clone current frame', self.viewer)
     self.cloneAction.setShortcut(QKeySequence.New)
@@ -102,6 +105,11 @@ class rMViewApp(QApplication):
     self.pauseAction.setShortcut('Ctrl+P')
     self.pauseAction.triggered.connect(self.toggleStreaming)
     self.viewer.addAction(self.pauseAction)
+    ###
+    self.invertColorsAction = QAction('Invert colors', checkable=True, checked=self.viewer.is_inverted())
+    self.invertColorsAction.setShortcut("Ctrl+I")
+    self.invertColorsAction.triggered.connect(self.invertColors)
+    self.viewer.addAction(self.invertColorsAction)
     ###
     self.settingsAction = QAction('Settings...', self.viewer)
     self.settingsAction.triggered.connect(self.openSettings)
@@ -136,6 +144,8 @@ class rMViewApp(QApplication):
     # inputMenu.addAction(self.rightAction)
     # inputMenu.addAction(self.homeAction)
     self.viewer.menu.addSeparator() # --------------------------
+    self.viewer.menu.addAction(self.invertColorsAction)
+    self.viewer.menu.addSeparator() # --------------------------
     self.viewer.menu.addAction(self.settingsAction)
     self.viewer.menu.addSeparator() # --------------------------
     self.viewer.menu.addAction(self.quitAction)
@@ -144,7 +154,7 @@ class rMViewApp(QApplication):
     self.viewer.show()
 
     # Display connecting image until we successfuly connect
-    self.viewer.setImage(QPixmap(':/assets/connecting.png'))
+    self.viewer.setImage(QImage(':/assets/connecting.png'))
 
     self.orient = 0
     orient = self.config.get('orientation', 'landscape')
@@ -440,7 +450,6 @@ class rMViewApp(QApplication):
   @pyqtSlot()
   def cloneViewer(self):
     img = self.viewer.image()
-    img = QPixmap.fromImage(img)
     img.detach()
     v = QtImageViewer()
     v.setAttribute(Qt.WA_DeleteOnClose)
@@ -464,6 +473,11 @@ class rMViewApp(QApplication):
       self.streaming = True
       self.pauseAction.setText("Pause Streaming")
       self.viewer.setWindowTitle("rMview - " + self.ssh.hostname)
+
+  @pyqtSlot()
+  def invertColors(self):
+    self.viewer.invert_colors()
+    self.fbworker.factory.instance.emitImage()
 
   @pyqtSlot()
   def openSettings(self, prompt=True):

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -93,7 +93,7 @@ class rMViewApp(QApplication):
       self.viewer.setBackgroundBrush(QBrush(QColor(self.config.get('background_color'))))
 
     if self.config.get('invert_colors'):
-        self.viewer.invert_colors()
+        self.viewer.invertColors()
 
     ### ACTIONS
     self.cloneAction = QAction('Clone current frame', self.viewer)
@@ -106,7 +106,7 @@ class rMViewApp(QApplication):
     self.pauseAction.triggered.connect(self.toggleStreaming)
     self.viewer.addAction(self.pauseAction)
     ###
-    self.invertColorsAction = QAction('Invert colors', checkable=True, checked=self.viewer.is_inverted())
+    self.invertColorsAction = QAction('Invert colors', checkable=True, checked=self.viewer.isInverted())
     self.invertColorsAction.setShortcut("Ctrl+I")
     self.invertColorsAction.triggered.connect(self.invertColors)
     self.viewer.addAction(self.invertColorsAction)
@@ -198,10 +198,10 @@ class rMViewApp(QApplication):
       portrait = False
 
     if portrait:
-      if not self.viewer.is_portrait():
+      if not self.viewer.isPortrait():
         self.viewer.portrait()
         self.autoResize(HEIGHT / WIDTH)
-    elif not self.viewer.is_landscape():
+    elif not self.viewer.isLandscape():
         self.viewer.landscape()
         self.autoResize(WIDTH / HEIGHT)
 
@@ -476,7 +476,7 @@ class rMViewApp(QApplication):
 
   @pyqtSlot()
   def invertColors(self):
-    self.viewer.invert_colors()
+    self.viewer.invertColors()
     self.fbworker.factory.instance.emitImage()
 
   @pyqtSlot()

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -106,11 +106,6 @@ class rMViewApp(QApplication):
     self.pauseAction.triggered.connect(self.toggleStreaming)
     self.viewer.addAction(self.pauseAction)
     ###
-    self.invertColorsAction = QAction('Invert colors', checkable=True, checked=self.viewer.isInverted())
-    self.invertColorsAction.setShortcut("Ctrl+I")
-    self.invertColorsAction.triggered.connect(self.viewer.invertColors)
-    self.viewer.addAction(self.invertColorsAction)
-    ###
     self.settingsAction = QAction('Settings...', self.viewer)
     self.settingsAction.triggered.connect(self.openSettings)
     self.viewer.addAction(self.settingsAction)
@@ -143,8 +138,6 @@ class rMViewApp(QApplication):
     # inputMenu.addAction(self.leftAction)
     # inputMenu.addAction(self.rightAction)
     # inputMenu.addAction(self.homeAction)
-    self.viewer.menu.addSeparator() # --------------------------
-    self.viewer.menu.addAction(self.invertColorsAction)
     self.viewer.menu.addSeparator() # --------------------------
     self.viewer.menu.addAction(self.settingsAction)
     self.viewer.menu.addSeparator() # --------------------------

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -108,7 +108,7 @@ class rMViewApp(QApplication):
     ###
     self.invertColorsAction = QAction('Invert colors', checkable=True, checked=self.viewer.isInverted())
     self.invertColorsAction.setShortcut("Ctrl+I")
-    self.invertColorsAction.triggered.connect(self.invertColors)
+    self.invertColorsAction.triggered.connect(self.viewer.invertColors)
     self.viewer.addAction(self.invertColorsAction)
     ###
     self.settingsAction = QAction('Settings...', self.viewer)
@@ -473,11 +473,6 @@ class rMViewApp(QApplication):
       self.streaming = True
       self.pauseAction.setText("Pause Streaming")
       self.viewer.setWindowTitle("rMview - " + self.ssh.hostname)
-
-  @pyqtSlot()
-  def invertColors(self):
-    self.viewer.invertColors()
-    self.fbworker.factory.instance.emitImage()
 
   @pyqtSlot()
   def openSettings(self, prompt=True):

--- a/src/rmview/viewer.py
+++ b/src/rmview/viewer.py
@@ -204,6 +204,15 @@ class QtImageViewer(QGraphicsView):
 
   def invertColors(self):
     self._invert_colors = not self._invert_colors
+    if self._pixmap:
+      img = self._pixmap.pixmap().toImage()
+      if not self._invert_colors:
+        img.invertPixels()
+      self.setImage(img)
+    if self._invert_colors:
+      self.setBackgroundBrush(Qt.black)
+    else:
+      self.setBackgroundBrush(Qt.white)
 
   def isInverted(self):
     return self._invert_colors

--- a/src/rmview/viewer.py
+++ b/src/rmview/viewer.py
@@ -80,6 +80,8 @@ class QtImageViewer(QGraphicsView):
     self._fit = True
     self._rotation = 0 # used to produce a rotated screenshot
 
+    self._invert_colors = False
+
   def contextMenuEvent(self, event):
     self.fitAction.setChecked(self._fit)
     self.menu.exec_(self.mapToGlobal(event.pos()))
@@ -103,12 +105,12 @@ class QtImageViewer(QGraphicsView):
     return None
 
   def setImage(self, image):
-    if type(image) is QPixmap:
-      pixmap = image
-    elif type(image) is QImage:
+    if type(image) is QImage:
+      if self._invert_colors:
+        image.invertPixels()
       pixmap = QPixmap.fromImage(image)
     else:
-      raise RuntimeError("ImageViewer.setImage: Argument must be a QImage or QPixmap.")
+      raise RuntimeError("ImageViewer.setImage: Argument must be a QImage.")
     if self.hasImage():
       self._pixmap.setPixmap(pixmap)
     else:
@@ -199,6 +201,12 @@ class QtImageViewer(QGraphicsView):
       if ok and fileName:
         img = img.transformed(QTransform().rotate(self._rotation))
         img.save(fileName)
+
+  def invert_colors(self):
+    self._invert_colors = not self._invert_colors
+
+  def is_inverted(self):
+    return self._invert_colors
 
   def is_landscape(self):
     return self._rotation == 90

--- a/src/rmview/viewer.py
+++ b/src/rmview/viewer.py
@@ -202,13 +202,13 @@ class QtImageViewer(QGraphicsView):
         img = img.transformed(QTransform().rotate(self._rotation))
         img.save(fileName)
 
-  def invert_colors(self):
+  def invertColors(self):
     self._invert_colors = not self._invert_colors
 
-  def is_inverted(self):
+  def isInverted(self):
     return self._invert_colors
 
-  def is_landscape(self):
+  def isLandscape(self):
     return self._rotation == 90
 
   def landscape(self):
@@ -217,7 +217,7 @@ class QtImageViewer(QGraphicsView):
     self._rotation = 90
     self.updateViewer()
 
-  def is_portrait(self):
+  def isPortrait(self):
     return self._rotation == 0
 
   def portrait(self):

--- a/src/rmview/viewer.py
+++ b/src/rmview/viewer.py
@@ -11,6 +11,11 @@ class QtImageViewer(QGraphicsView):
   zoomInFactor = 1.25
   zoomOutFactor = 1 / zoomInFactor
 
+  _fit = True
+  _rotation = 0 # used to produce a rotated screenshot
+  _invert_colors = False
+
+
   def __init__(self):
     QGraphicsView.__init__(self)
     self.setFrameStyle(QFrame.NoFrame)
@@ -60,6 +65,11 @@ class QtImageViewer(QGraphicsView):
     self.rotCCWAction.triggered.connect(self.rotateCCW)
     self.addAction(self.rotCCWAction)
     ###
+    self.invertColorsAction = QAction('Invert colors', checkable=True, checked=self.isInverted())
+    self.invertColorsAction.setShortcut("Ctrl+I")
+    self.invertColorsAction.triggered.connect(self.invertColors)
+    self.addAction(self.invertColorsAction)
+    ###
     self.screenshotAction = QAction('Save screenshot', self)
     self.screenshotAction.setShortcut(QKeySequence.Save)
     self.screenshotAction.triggered.connect(self.screenshot)
@@ -75,15 +85,13 @@ class QtImageViewer(QGraphicsView):
     self.menu.addAction(self.rotCWAction)
     self.menu.addAction(self.rotCCWAction)
     self.menu.addSeparator() # --------------------------
+    self.menu.addAction(self.invertColorsAction)
+    self.menu.addSeparator() # --------------------------
     self.menu.addAction(self.screenshotAction)
-
-    self._fit = True
-    self._rotation = 0 # used to produce a rotated screenshot
-
-    self._invert_colors = False
 
   def contextMenuEvent(self, event):
     self.fitAction.setChecked(self._fit)
+    self.invertColorsAction.setChecked(self._invert_colors)
     self.menu.exec_(self.mapToGlobal(event.pos()))
 
   def hasImage(self):


### PR DESCRIPTION
This PR adds a feature to invert the colors. Inversion can be set on startup with the `invert_colors` setting, which is `false` by default. Additionally, inversion can be toggled in the GUI menu.

While testing, there was no noticeable effect on latency. Inverting an image's pixels takes ~1ms on my machine.

Tested with screenshare on a RM2 running version 2.10.0.324.