### PR TITLE
Using `"auth_method": "password"` ignores SSH keys and agent

### DIFF
--- a/src/rmview/connection.py
+++ b/src/rmview/connection.py
@@ -64,13 +64,14 @@ class rMConnect(QRunnable):
   _known_hosts = None
 
   def __init__(self, address='10.11.99.1', username='root', password=None, key=None, timeout=3,
-               onConnect=None, onError=None, host_key_policy=None, known_hosts=None, **kwargs):
+               onConnect=None, onError=None, host_key_policy=None, known_hosts=None, auth_method=None, **kwargs):
     super(rMConnect, self).__init__()
 
     self.address = address
     self.username = username
     self.password = password
     self.timeout = timeout
+    self.auth_method = auth_method
     self.host_key_policy = host_key_policy
     self._known_hosts = known_hosts
 
@@ -138,6 +139,11 @@ class rMConnect(QRunnable):
         'pkey': self.pkey,
         'timeout': self.timeout,
       }
+
+      if self.auth_method == 'password':
+        self.options['look_for_keys'] = False
+        self.options['allow_agent'] = False
+
     except Exception as e:
       self._exception = e
 

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -221,6 +221,7 @@ class rMViewApp(QApplication):
     auth_method = self.config['ssh'].get('auth_method')
     if auth_method == 'password':
       self.config['ssh']['look_for_keys'] = False
+      self.config['ssh']['allow_agent'] = False
     if (auth_method == 'password' and 'password' not in self.config['ssh']) or \
        (auth_method is None and 'password' not in self.config['ssh'] and 'key' not in self.config['ssh']):
       password, ok = QInputDialog.getText(self.viewer, "Configuration","reMarkable password:", QLineEdit.Password)

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -219,6 +219,8 @@ class rMViewApp(QApplication):
         return False
 
     auth_method = self.config['ssh'].get('auth_method')
+    if auth_method == 'password':
+      self.config['ssh']['look_for_keys'] = False
     if (auth_method == 'password' and 'password' not in self.config['ssh']) or \
        (auth_method is None and 'password' not in self.config['ssh'] and 'key' not in self.config['ssh']):
       password, ok = QInputDialog.getText(self.viewer, "Configuration","reMarkable password:", QLineEdit.Password)

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -219,9 +219,6 @@ class rMViewApp(QApplication):
         return False
 
     auth_method = self.config['ssh'].get('auth_method')
-    if auth_method == 'password':
-      self.config['ssh']['look_for_keys'] = False
-      self.config['ssh']['allow_agent'] = False
     if (auth_method == 'password' and 'password' not in self.config['ssh']) or \
        (auth_method is None and 'password' not in self.config['ssh'] and 'key' not in self.config['ssh']):
       password, ok = QInputDialog.getText(self.viewer, "Configuration","reMarkable password:", QLineEdit.Password)


### PR DESCRIPTION
Solves #98