### PR TITLE
fix broken reference to ssh in `installDependencies`

### DIFF
--- a/src/rmview/screenstream/vnc.py
+++ b/src/rmview/screenstream/vnc.py
@@ -41,7 +41,7 @@ class VncStreamer(QRunnable):
   def installDependencies(self):
     sftp = self.ssh.open_sftp()
     from stat import S_IXUSR
-    fo = QFile(':bin/rM%d-vnc-server-standalone' % ssh.deviceVersion)
+    fo = QFile(':bin/rM%d-vnc-server-standalone' % self.ssh.deviceVersion)
     fo.open(QIODevice.ReadOnly)
     sftp.putfo(fo, 'rM-vnc-server-standalone')
     fo.close()


### PR DESCRIPTION
I always got errors when trying to use the automatic installer for the required components. This small change fixed it.