### PR TITLE
Fix connecting with new paramiko version

### DIFF
--- a/src/rmview/connection.py
+++ b/src/rmview/connection.py
@@ -137,6 +137,10 @@ class rMConnect(QRunnable):
         'password': self.password,
         'pkey': self.pkey,
         'timeout': self.timeout,
+        # remarkable's Dropbear version (Dropbear v2019.78) does not support the server-sig-algs extension,
+        # and also does not support sha2, so connection fails if sha2 is used
+        # paramiko starting with version 2.9.0, paramiko defaults to sha2 if not explicitly disabled: https://github.com/paramiko/paramiko/issues/1961
+        'disabled_algorithms': {'pubkeys': ['rsa-sha2-512', 'rsa-sha2-256']},
       }
     except Exception as e:
       self._exception = e


### PR DESCRIPTION
Connecting to remarkable with 2.9 fails without this fix