### PR TITLE
Updated to use PyQt6 instead of PyQt5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY src ./src
 RUN pip install --upgrade pip
 # TODO: setup.py could to be fixed to include install_requires
 #       see also: https://stackoverflow.com/q/21915469/543875
-RUN pip install pyqt5==5.14.2 paramiko twisted
+RUN pip install pyqt6==6.2.3 paramiko twisted
 RUN pip install .[tunnel]
 RUN pip cache purge
 CMD rmview

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ If you plan to modify the source code, use `pip install -e .` so that when execu
 
 ### Manual installation
 
-Install the dependencies ([PyQt5][pyqt5], [Paramiko][paramiko], [Twisted][twisted], [PyJWT][pyjwt]) with `pip` or `conda` manually:
+Install the dependencies ([PyQt6][pyqt6], [Paramiko][paramiko], [Twisted][twisted], [PyJWT][pyjwt]) with `pip` or `conda` manually:
 
     # install dependencies
-    pip install pyqt5 paramiko twisted pyjwt
+    pip install pyqt6 paramiko twisted pyjwt
     pip install sshtunnel  # optional
     # build resources file
     pyrcc5 -o src/rmview/resources.py resources.qrc
@@ -256,7 +256,7 @@ GPLv3
 
 [py3]: https://www.python.org/downloads/
 [anaconda]: https://docs.anaconda.com/anaconda
-[pyqt5]: https://www.riverbankcomputing.com/software/pyqt/
+[pyqt6]: https://www.riverbankcomputing.com/software/pyqt/
 [paramiko]: http://www.paramiko.org/
 [twisted]: https://twistedmatrix.com/trac/
 [pyjwt]: https://pypi.org/project/PyJWT/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "PyQt5"]
+requires = ["setuptools", "wheel", "PyQt6"]

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,13 @@ from setuptools import setup, find_packages
 
 import sys
 
+import PyQt6.QtCore as QtCore
+
 def genResources():
-    from PyQt5.pyrcc_main import main as pyrcc_main
+    QtCore.QDir.addSearchPath('assets', 'assets/')
+    QtCore.QDir.addSearchPath('bin', 'bin/')
     saved_argv = sys.argv
     # Use current environment to find pyrcc but use the public interface
-    sys.argv = ['pyrcc5', '-o', 'src/rmview/resources.py', 'resources.qrc']
-    pyrcc_main()
     sys.argv = saved_argv
 
 # https://stackoverflow.com/questions/19569557/pip-not-picking-up-a-custom-install-cmdclass
@@ -41,7 +42,7 @@ setup(
     'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
   ],
   packages=['rmview', 'rmview.screenstream'],
-  install_requires=['pyqt5', 'paramiko', 'twisted[tls]', 'pyjwt'],
+  install_requires=['pyqt6', 'paramiko', 'twisted[tls]', 'pyjwt'],
   extras_require = { 'tunnel': ['sshtunnel'] },
   entry_points={
     'console_scripts':['rmview = rmview.rmview:rmViewMain']

--- a/src/rmview/connection.py
+++ b/src/rmview/connection.py
@@ -1,6 +1,6 @@
-# from PyQt5.QtGui import *
-from PyQt5.QtCore import *
-from PyQt5.QtWidgets import *
+# from PyQt6.QtGui import *
+from PyQt6.QtCore import *
+from PyQt6.QtWidgets import *
 
 
 import paramiko
@@ -86,7 +86,7 @@ class rMConnect(QRunnable):
           self.pkey = paramiko.RSAKey.from_private_key_file(key)
         except paramiko.ssh_exception.PasswordRequiredException:
           passphrase, ok = QInputDialog.getText(None, "Configuration","SSH key passphrase:",
-                                                QLineEdit.Password)
+                                                QLineEdit.EchoMode.Password)
           if ok:
             self.pkey = paramiko.RSAKey.from_private_key_file(key, password=passphrase)
           else:

--- a/src/rmview/pentracker.py
+++ b/src/rmview/pentracker.py
@@ -1,6 +1,6 @@
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
-from PyQt5.QtCore import *
+from PyQt6.QtGui import *
+from PyQt6.QtWidgets import *
+from PyQt6.QtCore import *
 
 from .rmparams import *
 

--- a/src/rmview/screenstream/common.py
+++ b/src/rmview/screenstream/common.py
@@ -1,8 +1,8 @@
 import logging
 import atexit
 
-from PyQt5.QtGui import *
-from PyQt5.QtCore import *
+from PyQt6.QtGui import *
+from PyQt6.QtCore import *
 
 from twisted.internet import reactor
 from twisted.internet.error import ConnectionRefusedError
@@ -10,7 +10,7 @@ from twisted.internet.error import ConnectionRefusedError
 from ..rmparams import *
 from ..rfb import *
 
-IMG_FORMAT = QImage.Format_RGB16
+IMG_FORMAT = QImage.Format.Format_RGB16
 BYTES_PER_PIXEL = 2
 
 log = logging.getLogger('rmview')

--- a/src/rmview/screenstream/screenshare.py
+++ b/src/rmview/screenstream/screenshare.py
@@ -1,6 +1,6 @@
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
-from PyQt5.QtCore import *
+from PyQt6.QtGui import *
+from PyQt6.QtWidgets import *
+from PyQt6.QtCore import *
 
 from rmview.rmparams import *
 

--- a/src/rmview/screenstream/vnc.py
+++ b/src/rmview/screenstream/vnc.py
@@ -1,8 +1,8 @@
 import logging
 import atexit
 
-from PyQt5.QtGui import *
-from PyQt5.QtCore import *
+from PyQt6.QtGui import *
+from PyQt6.QtCore import *
 
 from twisted.internet import reactor
 from twisted.application import internet
@@ -41,7 +41,7 @@ class VncStreamer(QRunnable):
   def installDependencies(self):
     sftp = self.ssh.open_sftp()
     from stat import S_IXUSR
-    fo = QFile(':bin/rM%d-vnc-server-standalone' % self.ssh.deviceVersion)
+    fo = QFile('bin:rM%d-vnc-server-standalone' % self.ssh.deviceVersion)
     fo.open(QIODevice.ReadOnly)
     sftp.putfo(fo, 'rM-vnc-server-standalone')
     fo.close()

--- a/src/rmview/viewer.py
+++ b/src/rmview/viewer.py
@@ -1,6 +1,6 @@
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from PyQt6.QtCore import *
+from PyQt6.QtGui import *
+from PyQt6.QtWidgets import *
 
 def _invertColor(c):
   (r, g, b, a) = c.getRgb()
@@ -22,21 +22,21 @@ class QtImageViewer(QGraphicsView):
 
   def __init__(self):
     QGraphicsView.__init__(self)
-    self.setFrameStyle(QFrame.NoFrame)
+    self.setFrameStyle(QFrame.Shape.NoFrame)
 
-    self.setRenderHint(QPainter.Antialiasing)
-    self.setRenderHint(QPainter.SmoothPixmapTransform)
+    self.setRenderHint(QPainter.RenderHint.Antialiasing)
+    self.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform)
 
-    self.viewport().grabGesture(Qt.PinchGesture)
+    self.viewport().grabGesture(Qt.GestureType.PinchGesture)
 
     self.scene = QGraphicsScene()
     self.setScene(self.scene)
 
     self._pixmap = None
-    self.aspectRatioMode = Qt.KeepAspectRatio
-    self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-    self.setVerticalScrollBarPolicy(Qt.ScrollBarAsNeeded)
-    self.setAlignment(Qt.AlignCenter)
+    self.aspectRatioMode = Qt.AspectRatioMode.KeepAspectRatio
+    self.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+    self.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+    self.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
     ### ACTIONS
     self.fitAction = QAction('Fit to view', self, checkable=True)
@@ -50,12 +50,12 @@ class QtImageViewer(QGraphicsView):
     self.addAction(self.actualSizeAction)
     ###
     self.zoomInAction = QAction('Zoom In', self)
-    self.zoomInAction.setShortcut(QKeySequence.ZoomIn)
+    self.zoomInAction.setShortcut(QKeySequence.StandardKey.ZoomIn)
     self.zoomInAction.triggered.connect(self.zoomIn)
     self.addAction(self.zoomInAction)
     ###
     self.zoomOutAction = QAction('Zoom Out', self)
-    self.zoomOutAction.setShortcut(QKeySequence.ZoomOut)
+    self.zoomOutAction.setShortcut(QKeySequence.StandardKey.ZoomOut)
     self.zoomOutAction.triggered.connect(self.zoomOut)
     self.addAction(self.zoomOutAction)
     ###
@@ -75,7 +75,7 @@ class QtImageViewer(QGraphicsView):
     self.addAction(self.invertColorsAction)
     ###
     self.screenshotAction = QAction('Save screenshot', self)
-    self.screenshotAction.setShortcut(QKeySequence.Save)
+    self.screenshotAction.setShortcut(QKeySequence.StandardKey.Save)
     self.screenshotAction.triggered.connect(self.screenshot)
     self.addAction(self.screenshotAction)
     ###
@@ -128,7 +128,7 @@ class QtImageViewer(QGraphicsView):
     else:
       self._pixmap = self.scene.addPixmap(pixmap)
       self._pixmap.setZValue(-1)
-    self._pixmap.setTransformationMode(Qt.SmoothTransformation)
+    self._pixmap.setTransformationMode(Qt.TransformationMode.SmoothTransformation)
     self.setSceneRect(QRectF(pixmap.rect()))  # Set scene size to image size.
     # self.fitInView(self.sceneRect(), self.aspectRatioMode)  # Show entire image (use current aspect ratio mode).
     self.updateViewer()
@@ -144,9 +144,9 @@ class QtImageViewer(QGraphicsView):
     self.updateViewer()
 
   def mousePressEvent(self, event):
-    if event.button() == Qt.LeftButton:
+    if event.button() == Qt.MouseButton.LeftButton:
       scenePos = self.mapToScene(event.pos())
-      if int(event.modifiers()) & int(Qt.ControlModifier):
+      if int(event.modifiers()) & int(Qt.KeyboardModifier.ControlModifier):
         self._button = 1
       else:
         self._button = 4
@@ -173,8 +173,8 @@ class QtImageViewer(QGraphicsView):
     QGraphicsView.mouseDoubleClickEvent(self, event)
 
   def viewportEvent(self, event):
-    if event.type() == QEvent.Gesture:
-      pinch = event.gesture(Qt.PinchGesture)
+    if event.type() == QEvent.Type.Gesture:
+      pinch = event.gesture(Qt.GestureType.PinchGesture)
       if pinch is not None:
         self._fit = False
         self.scale(pinch.scaleFactor(), pinch.scaleFactor())
@@ -182,13 +182,13 @@ class QtImageViewer(QGraphicsView):
     return bool(QGraphicsView.viewportEvent(self, event))
 
   def wheelEvent(self, event):
-    if event.modifiers() == Qt.NoModifier:
+    if event.modifiers() == Qt.KeyboardModifier.NoModifier:
       QGraphicsView.wheelEvent(self, event)
     else:
       self._fit = False
 
-      self.setTransformationAnchor(QGraphicsView.NoAnchor)
-      self.setResizeAnchor(QGraphicsView.NoAnchor)
+      self.setTransformationAnchor(QGraphicsView.ViewportAnchor.NoAnchor)
+      self.setResizeAnchor(QGraphicsView.ViewportAnchor.NoAnchor)
 
       oldPos = self.mapToScene(event.pos())
 
@@ -246,16 +246,16 @@ class QtImageViewer(QGraphicsView):
   def rotateCW(self):
     self.rotate(90)
     self._rotation += 90
-    if not self.windowState() & (QWindow.FullScreen | QWindow.Maximized):
-      s = QApplication.desktop().availableGeometry(self).size()
+    if not self.windowState() in [QWindow.Visibility.FullScreen, QWindow.Visibility.Maximized]:
+      s = QGuiApplication.primaryScreen().availableGeometry().size()
       self.resize(self.size().transposed().boundedTo(s))
     self.updateViewer()
 
   def rotateCCW(self):
     self.rotate(-90)
     self._rotation -= 90
-    if not self.windowState() & (QWindow.FullScreen | QWindow.Maximized):
-      s = QApplication.desktop().availableGeometry(self).size()
+    if not self.windowState() in [QWindow.Visibility.FullScreen, QWindow.Visibility.Maximized]:
+      s = QGuiApplication.primaryScreen().availableGeometry().size()
       self.resize(self.size().transposed().boundedTo(s))
     self.updateViewer()
 
@@ -278,14 +278,14 @@ class QtImageViewer(QGraphicsView):
     self.rotate(self._rotation)
 
   def keyPressEvent(self, event):
-    if event.key() == Qt.Key_F:
+    if event.key() == Qt.Key.Key_F:
       self.setFit(True)
-    elif event.key() == Qt.Key_1:
+    elif event.key() == Qt.Key.Key_1:
       self.actualSize()
-    elif event.key() == Qt.Key_S:
+    elif event.key() == Qt.Key.Key_S:
       self.screenshot()
-    elif event.key() == Qt.Key_Plus:
+    elif event.key() == Qt.Key.Key_Plus:
       self.zoomIn()
-    elif event.key() == Qt.Key_Minus:
+    elif event.key() == Qt.Key.Key_Minus:
       self.zoomOut()
 

--- a/src/rmview/viewer.py
+++ b/src/rmview/viewer.py
@@ -96,7 +96,7 @@ class QtImageViewer(QGraphicsView):
   def contextMenuEvent(self, event):
     self.fitAction.setChecked(self._fit)
     self.invertColorsAction.setChecked(self._invert_colors)
-    self.menu.exec_(self.mapToGlobal(event.pos()))
+    self.menu.exec(self.mapToGlobal(event.pos()))
 
   def hasImage(self):
     return self._pixmap is not None


### PR DESCRIPTION
As PyQt5 is not compatible with M1 Macs, this PR changes to use PyQt6.

At the moment I've gotten as far as to load the the screen from the Remarkable, but something fails then.

Most of the changes are related to qt6 has changed references to most functions, with intermediate functions.

This fixes #119