### PR TITLE
Fix local variable 'version_server' referenced before assignment

### DIFF
--- a/src/rmview/rfb.py
+++ b/src/rmview/rfb.py
@@ -181,6 +181,7 @@ class RFBClient(Protocol):
         buffer = b''.join(self._packet)
         if b'\n' in buffer:
             version = 3.8
+            version_server = 3.8
             if buffer[:3] == b'RFB':
                 version_server = float(buffer[3:-1].replace(b'0', b''))
                 SUPPORTED_VERSIONS = (3.3, 3.7, 3.8)


### PR DESCRIPTION
I have the issue with my RM1 which is on software 3.0.3

```
Unhandled Error
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/twisted/python/log.py", line 96, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File "/usr/local/lib/python3.9/site-packages/twisted/python/log.py", line 80, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "/usr/local/lib/python3.9/site-packages/twisted/python/context.py", line 117, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/usr/local/lib/python3.9/site-packages/twisted/python/context.py", line 82, in callWithContext
    return func(*args, **kw)
--- <exception caught here> ---
  File "/usr/local/lib/python3.9/site-packages/twisted/internet/posixbase.py", line 487, in _doReadOrWrite
    why = selectable.doRead()
  File "/usr/local/lib/python3.9/site-packages/twisted/internet/tcp.py", line 248, in doRead
    return self._dataReceived(data)
  File "/usr/local/lib/python3.9/site-packages/twisted/internet/tcp.py", line 253, in _dataReceived
    rval = self.protocol.dataReceived(data)
  File "/usr/local/lib/python3.9/site-packages/twisted/protocols/tls.py", line 329, in dataReceived
    self._flushReceiveBIO()
  File "/usr/local/lib/python3.9/site-packages/twisted/protocols/tls.py", line 295, in _flushReceiveBIO
    ProtocolWrapper.dataReceived(self, bytes)
  File "/usr/local/lib/python3.9/site-packages/twisted/protocols/policies.py", line 110, in dataReceived
    self.wrappedProtocol.dataReceived(data)
  File "/usr/local/lib/python3.9/site-packages/rmview/rfb.py", line 722, in dataReceived
    self._handler()
  File "/usr/local/lib/python3.9/site-packages/rmview/rfb.py", line 195, in _handleInitial
    version = version_server
```