### PR TITLE
Fix typos

### DIFF
--- a/src/rmview/connection.py
+++ b/src/rmview/connection.py
@@ -125,7 +125,7 @@ class rMConnect(QRunnable):
           # ideally we would want to always load the system ones
           # and have the local keys have precedence, but paramiko gives
           # always precedence to system keys
-          # There is extremly slow in system with many known host entries... :/
+          # There is extremely slow in system with many known host entries... :/
           # See https://github.com/paramiko/paramiko/issues/191
           self.client.load_system_host_keys()
           log.info("System default known host file loaded")

--- a/src/rmview/rfb.py
+++ b/src/rmview/rfb.py
@@ -231,7 +231,7 @@ class RFBClient(Protocol):
                 else:
                     self.expect(self._handleVNCAuthResult, 4)
             elif sec_type == RM_AUTH:
-                self.expect(self._handleRMAuth, 4) 
+                self.expect(self._handleRMAuth, 4)
             else:
                 self.expect(self._handleVNCAuth, 16)
         else:
@@ -394,7 +394,7 @@ class RFBClient(Protocol):
             elif encoding == PSEUDO_CURSOR_ENCODING:
                 length = width * height * self.bypp
                 length += int(math.floor((width + 7.0) / 8)) * height
-                self.expect(self._handleDecodePsuedoCursor, length, x, y, width, height)
+                self.expect(self._handleDecodePseudoCursor, length, x, y, width, height)
             elif encoding == PSEUDO_DESKTOP_SIZE_ENCODING:
                 self._handleDecodeDesktopSize(width, height)
             else:
@@ -469,7 +469,7 @@ class RFBClient(Protocol):
         #~ print "_doNextHextileSubrect %r" % ((color, x, y, width, height, tx, ty), )
         #coords of next tile
         #its line after line of tiles
-        #finished when the last line is completly received
+        #finished when the last line is completely received
 
         #dont inc the first time
         if tx is not None:
@@ -688,7 +688,7 @@ class RFBClient(Protocol):
         self._doConnection()
 
     # --- Pseudo Cursor Encoding
-    def _handleDecodePsuedoCursor(self, block, x, y, width, height):
+    def _handleDecodePseudoCursor(self, block, x, y, width, height):
         split = width * height * self.bypp
         image = block[:split]
         mask = block[split:]
@@ -748,7 +748,7 @@ class RFBClient(Protocol):
     def setPixelFormat(self, bpp=32, depth=24, bigendian=0, truecolor=1, redmax=255, greenmax=255, bluemax=255, redshift=0, greenshift=8, blueshift=16):
         pixformat = pack("!BBBBHHHBBBxxx", bpp, depth, bigendian, truecolor, redmax, greenmax, bluemax, redshift, greenshift, blueshift)
         self.transport.write(pack("!Bxxx16s", 0, pixformat))
-        #rember these settings
+        #remember these settings
         self.bpp, self.depth, self.bigendian, self.truecolor = bpp, depth, bigendian, truecolor
         self.redmax, self.greenmax, self.bluemax = redmax, greenmax, bluemax
         self.redshift, self.greenshift, self.blueshift = redshift, greenshift, blueshift
@@ -789,7 +789,7 @@ class RFBClient(Protocol):
     #------------------------------------------------------
     def vncConnectionMade(self):
         """connection is initialized and ready.
-           typicaly, the pixel format is set here."""
+           typically, the pixel format is set here."""
 
     def vncRequestPassword(self):
         """a password is needed to log on, use sendPassword() to
@@ -812,7 +812,7 @@ class RFBClient(Protocol):
     def commitUpdate(self, rectangles=None):
         """called after a series of updateRectangle(), copyRectangle()
            or fillRectangle() are finished.
-           typicaly, here is the place to request the next screen
+           typically, here is the place to request the next screen
            update with FramebufferUpdateRequest(incremental=1).
            argument is a list of tuples (x,y,w,h) with the updated
            rectangles."""
@@ -848,16 +848,15 @@ class RFBClient(Protocol):
 
     def getRMChallenge(self):
         raise Exception("should be implemented in the subclass")
-        
+
 
 class RFBFactory(protocol.ClientFactory):
     """A factory for remote frame buffer connections."""
 
     # the class of the protocol to build
-    # should be overriden by application to use a derrived class
+    # should be overridden by application to use a derived class
     protocol = RFBClient
 
     def __init__(self, password = None, shared = 1):
         self.password = password
         self.shared = shared
-        

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -148,7 +148,7 @@ class rMViewApp(QApplication):
     self.viewer.setWindowTitle("rMview")
     self.viewer.show()
 
-    # Display connecting image until we successfuly connect
+    # Display connecting image until we successfully connect
     self.viewer.setImage(QImage(':/assets/connecting.png'))
 
     self.orient = 0
@@ -593,7 +593,7 @@ def rmViewMain():
   log.info("STARTING: %s", time.asctime())
   QCoreApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
   app = rMViewApp(sys.argv)
-  # We register custom signal handler so we can gracefuly stop app with CTRL+C when QT main loop is
+  # We register custom signal handler so we can gracefully stop app with CTRL+C when QT main loop is
   # running
   signal.signal(signal.SIGINT, lambda *args: app.quit())
   ecode = app.exec_()


### PR DESCRIPTION
Found via `codespell -S .mypy_cache -L ans,fo`