### PR TITLE
Fix for issue #146

### DIFF
--- a/src/rmview/rmparams.py
+++ b/src/rmview/rmparams.py
@@ -18,8 +18,10 @@ def timestamp_to_version(ts):
     return (2, 7, 0, 0)
   elif ts < SW_VER_TIMESTAMPS["2.9.1.236"]:
     return (2, 9, 0, 0)
-  else:
+  elif ts == SW_VER_TIMESTAMPS["2.9.1.236"]:
     return (2, 9, 1, 236)
+  else:
+    return (2, 9, 1, 9999) # Phony version number. Just needs to compare > 2.9.1.236
 
 
 # evtype_sync = 0

--- a/src/rmview/rmparams.py
+++ b/src/rmview/rmparams.py
@@ -9,6 +9,18 @@ SW_VER_TIMESTAMPS = {
   '2.9.1.236': 20210820111232
 }
 
+# This mapping was adapted from the above `SW_VER_TIMESTAMPS` dictionary. 
+# Newer versions do not use timestamp based versioning, and are likewise not represented here.
+def timestamp_to_version(ts):
+  if ts < SW_VER_TIMESTAMPS["2.7"]:
+    return (2, 6, 0, 0)
+  elif ts < SW_VER_TIMESTAMPS["2.9"]:
+    return (2, 7, 0, 0)
+  elif ts < SW_VER_TIMESTAMPS["2.9.1.236"]:
+    return (2, 9, 0, 0)
+  else:
+    return (2, 9, 1, 236)
+
 
 # evtype_sync = 0
 e_type_key = 1

--- a/src/rmview/rmview.py
+++ b/src/rmview/rmview.py
@@ -302,7 +302,7 @@ class rMViewApp(QApplication):
     self.ssh = ssh
     self.viewer.setWindowTitle("rMview - " + ssh.hostname)
 
-    log.info("Detected %s", ssh.fullDeviceVersion)
+    log.info("Detected device: %s", ssh.fullDeviceVersion)
     version = ssh.deviceVersion
     if version not in [1, 2]:
       log.error("Device is unsupported: '%s' [%s]", ssh.fullDeviceVersion, version or "unknown device")
@@ -312,11 +312,11 @@ class rMViewApp(QApplication):
 
     backend = self.config.get('backend', 'auto')
     if backend == 'auto':
-      if ssh.softwareVersion >= SW_VER_TIMESTAMPS['2.9']:
+      if ssh.softwareVersion >= (2, 9, 0, 0):
         backend = 'screenshare'
       else:
         backend = 'vncserver'
-        if ssh.softwareVersion >= SW_VER_TIMESTAMPS['2.7']:
+        if ssh.softwareVersion >= (2, 7, 0, 0):
           log.warning("Detected version 2.7 or 2.8. The server might not work with these versions.")
 
     log.info("Using backend '%s'", backend)

--- a/src/rmview/screenstream/screenshare.py
+++ b/src/rmview/screenstream/screenshare.py
@@ -134,7 +134,7 @@ class ScreenShareStream(QRunnable):
   def run(self):
       log.info("Connecting to ScreenShare, make sure you enable it")
       try:
-        if self.ssh.softwareVersion > SW_VER_TIMESTAMPS['2.9.1.236']:
+        if self.ssh.softwareVersion > (2, 9, 1, 236):
           log.warning("Authenticating, please wait...")
           challengeReader = ChallengeReaderProtocol(self.runVnc)
           reactor.listenUDP(5901, challengeReader)


### PR DESCRIPTION
The issue arises due to the reMarkable software version no longer being accurately reflected in `/etc/version`. This causes rmview to think it is connecting to an older version.

I've fixed this by switching rmview's SW version logic over to the semantic versioning scheme used by recent releases. The SW version is taken from the `REMARKABLE_RELEASE_VERSION` value in `/usr/share/remarkable/update.conf`, as suggested by @Eeems. Support for older versions is to be maintained by mapping the older timestamp version numbers back to the corresponding semantic versions.

**Note:** I tried to make this fully compatible with the prior rmview behavior and older SW versions, but I have not tested it on older SW versions. A quick test or two from folks running a version < 3.6 would be appreciated. 