### PR TITLE
Fix screenshare in Remarkable 3.11

### DIFF
--- a/src/rmview/screenstream/screenshare.py
+++ b/src/rmview/screenstream/screenshare.py
@@ -96,8 +96,21 @@ class ScreenShareStream(QRunnable):
   reads the usedId from deviceToken from the config file on the rm
   """
   def get_userid(self):
+    files = ['/etc/remarkable.conf', '/home/root/.config/remarkable/xochitl.conf']
     with self.ssh.open_sftp() as sftp:
-      with sftp.file('/home/root/.config/remarkable/xochitl.conf') as f:
+      for f in files:
+        try:
+          if sftp.stat(f):
+            file = f
+            break 
+        except Exception:
+          pass
+      if not file:
+        # Never should be here or unhealthy device
+        log.error('No remote config file detected on your Remarkable.')
+      
+      log.info('Remote config file detected: ' + file)
+      with sftp.file(file) as f:
         file_content = f.read().decode()
 
     cfg = configparser.ConfigParser(strict=False)

--- a/src/rmview/screenstream/screenshare.py
+++ b/src/rmview/screenstream/screenshare.py
@@ -97,7 +97,7 @@ class ScreenShareStream(QRunnable):
   """
   def get_userid(self):
     with self.ssh.open_sftp() as sftp:
-      with sftp.file('/etc/remarkable.conf') as f:
+      with sftp.file('/home/root/.config/remarkable/xochitl.conf') as f:
         file_content = f.read().decode()
 
     cfg = configparser.ConfigParser(strict=False)


### PR DESCRIPTION
Hello folks,
my Remarkable just got updated and the Screenshare got in a failing loop with the followign error: 

```
[INFO] received timestamp challenge 1714161646899
Unhandled Error
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/twisted/python/log.py", line 80, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "/usr/local/lib/python3.10/dist-packages/twisted/python/context.py", line 117, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/usr/local/lib/python3.10/dist-packages/twisted/python/context.py", line 82, in callWithContext
    return func(*args, **kw)
  File "/usr/local/lib/python3.10/dist-packages/twisted/internet/posixbase.py", line 482, in _doReadOrWrite
    why = selectable.doRead()
--- <exception caught here> ---
  File "/usr/local/lib/python3.10/dist-packages/twisted/internet/udp.py", line 254, in doRead
    self.protocol.datagramReceived(data, addr)
  File "/usr/local/lib/python3.10/dist-packages/rmview/screenstream/screenshare.py", line 46, in datagramReceived
    if not self.callback(timestamp):
  File "/usr/local/lib/python3.10/dist-packages/rmview/screenstream/screenshare.py", line 120, in runVnc
    userId = self.get_userid()
  File "/usr/local/lib/python3.10/dist-packages/rmview/screenstream/screenshare.py", line 101, in get_userid
    with sftp.file('/etc/remarkable.conf') as f:
  File "/usr/lib/python3/dist-packages/paramiko/sftp_client.py", line 372, in open
    t, msg = self._request(CMD_OPEN, filename, imode, attrblock)
  File "/usr/lib/python3/dist-packages/paramiko/sftp_client.py", line 822, in _request
    return self._read_response(num)
  File "/usr/lib/python3/dist-packages/paramiko/sftp_client.py", line 874, in _read_response
    self._convert_status(msg)
  File "/usr/lib/python3/dist-packages/paramiko/sftp_client.py", line 903, in _convert_status
    raise IOError(errno.ENOENT, text)
builtins.FileNotFoundError: [Errno 2] No such file
```

Seems like the /etc/remarkable.conf file is moved to /home/root/.config/remarkable/xochitl.conf in version 3.11.
