### PR TITLE
feat: support non-RSA ssh keys (Ed25519Key, ECDSAKey...)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
   ],
   packages=['rmview', 'rmview.screenstream'],
-  install_requires=['pyqt5', 'paramiko', 'twisted[tls]', 'pyjwt'],
+  install_requires=['pyqt5', 'paramiko', 'twisted[tls]', 'pyjwt', 'cryptography'],
   extras_require = { 'tunnel': ['sshtunnel'] },
   entry_points={
     'console_scripts':['rmview = rmview.rmview:rmViewMain']

--- a/src/rmview/connection.py
+++ b/src/rmview/connection.py
@@ -3,7 +3,7 @@ from PyQt5.QtCore import *
 from PyQt5.QtWidgets import *
 
 from .rmparams import timestamp_to_version
-
+from .ssh_key import from_private_key_file
 
 import paramiko
 import struct
@@ -82,10 +82,10 @@ class rMConnect(QRunnable):
 
       if password:
         # password protected key file, password provided in the config
-        self.pkey = paramiko.RSAKey.from_private_key_file(key, password=password)
+        self.pkey = from_private_key_file(key, password=password)
       else:
         try:
-          self.pkey = paramiko.RSAKey.from_private_key_file(key)
+          self.pkey = from_private_key_file(key)
         except paramiko.ssh_exception.PasswordRequiredException:
           passphrase, ok = QInputDialog.getText(None, "Configuration","SSH key passphrase:",
                                                 QLineEdit.Password)

--- a/src/rmview/ssh_key.py
+++ b/src/rmview/ssh_key.py
@@ -1,0 +1,47 @@
+from io import StringIO
+from paramiko import RSAKey, Ed25519Key, ECDSAKey, DSSKey, PKey
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519, dsa, rsa, ec
+
+# This method checks the key type using the cryptography library and returns the corresponding Paramiko PKey.
+# Allows SSH authentication with non-RSA keys
+# Based on https://stackoverflow.com/a/72512148
+def from_private_key_file(filename, password=None) -> PKey:
+    with open(filename) as file_obj:
+        private_key = None
+        file_bytes = bytes(file_obj.read(), "utf-8")
+        try:
+            key = crypto_serialization.load_ssh_private_key(
+                file_bytes,
+                password=password,
+            )
+            file_obj.seek(0)
+        except ValueError:
+            key = crypto_serialization.load_pem_private_key(
+                file_bytes,
+                password=password,
+            )
+            if password:
+                encryption_algorithm = crypto_serialization.BestAvailableEncryption(
+                    password
+                )
+            else:
+                encryption_algorithm = crypto_serialization.NoEncryption()
+            file_obj = StringIO(
+                key.private_bytes(
+                    crypto_serialization.Encoding.PEM,
+                    crypto_serialization.PrivateFormat.OpenSSH,
+                    encryption_algorithm,
+                ).decode("utf-8")
+            )
+        if isinstance(key, rsa.RSAPrivateKey):
+            private_key = RSAKey.from_private_key(file_obj, password)
+        elif isinstance(key, ed25519.Ed25519PrivateKey):
+            private_key = Ed25519Key.from_private_key(file_obj, password)
+        elif isinstance(key, ec.EllipticCurvePrivateKey):
+            private_key = ECDSAKey.from_private_key(file_obj, password)
+        elif isinstance(key, dsa.DSAPrivateKey):
+            private_key = DSSKey.from_private_key(file_obj, password)
+        else:
+            raise TypeError
+        return private_key


### PR DESCRIPTION
Adds support for non-RSA keys to authenticate to the reMarkable (Ed25519Key, ECDSAKey, DSSKey).

First  loads the key and checks the type, then returns the relevant paramiko PKey object.

Fixes the cryptic error that happened when loading a non-RSA key:

```log
[INFO] STARTING: Wed Jun  5 10:02:52 2024
QStandardPaths: XDG_RUNTIME_DIR not set, defaulting to '/tmp/runtime-root'
[INFO] Searching configuration in rmview.json, /root/.config/rmview.json
[INFO] Fetching configuration from /root/.config/rmview.json
[WARNING] Config file "/root/.config/rmview.json" is readable by others (permissions=644). If your config file contains secrets (e.g. password) you are strongly encouraged to make sure it's not readable by other users (chmod 600 /root/.config/rmview.json)
libGL error: MESA-LOADER: failed to retrieve device information
libGL error: Version 4 or later of flush extension not found
libGL error: failed to load driver: i915
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/paramiko/pkey.py", line 698, in _uint32_cstruct_unpack
    s_size = struct.unpack(">L", data[idx : idx + 4])[0]
struct.error: unpack requires a buffer of 4 bytes

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/rmview", line 8, in <module>
    sys.exit(rmViewMain())
  File "/usr/local/lib/python3.9/site-packages/rmview/rmview.py", line 601, in rmViewMain
    app = rMViewApp(sys.argv)
  File "/usr/local/lib/python3.9/site-packages/rmview/rmview.py", line 186, in __init__
    self.requestConnect()
  File "/usr/local/lib/python3.9/site-packages/rmview/rmview.py", line 289, in requestConnect
    rMConnect(**args,
  File "/usr/local/lib/python3.9/site-packages/rmview/connection.py", line 88, in __init__
    self.pkey = paramiko.RSAKey.from_private_key_file(key)
  File "/usr/local/lib/python3.9/site-packages/paramiko/pkey.py", line 421, in from_private_key_file
    key = cls(filename=filename, password=password)
  File "/usr/local/lib/python3.9/site-packages/paramiko/rsakey.py", line 64, in __init__
    self._from_private_key_file(filename, password)
  File "/usr/local/lib/python3.9/site-packages/paramiko/rsakey.py", line 197, in _from_private_key_file
    self._decode_key(data)
  File "/usr/local/lib/python3.9/site-packages/paramiko/rsakey.py", line 213, in _decode_key
    n, e, d, iqmp, p, q = self._uint32_cstruct_unpack(data, "iiiiii")
  File "/usr/local/lib/python3.9/site-packages/paramiko/pkey.py", line 718, in _uint32_cstruct_unpack
    raise SSHException(str(e))
paramiko.ssh_exception.SSHException: unpack requires a buffer of 4 bytes
```