### PR TITLE
Fix pylint warning `raise-missing-from`

### DIFF
--- a/src/rmview/connection.py
+++ b/src/rmview/connection.py
@@ -86,13 +86,13 @@ class rMConnect(QRunnable):
       else:
         try:
           self.pkey = paramiko.RSAKey.from_private_key_file(key)
-        except paramiko.ssh_exception.PasswordRequiredException:
+        except paramiko.ssh_exception.PasswordRequiredException as exc:
           passphrase, ok = QInputDialog.getText(None, "Configuration","SSH key passphrase:",
                                                 QLineEdit.Password)
           if ok:
             self.pkey = paramiko.RSAKey.from_private_key_file(key, password=passphrase)
           else:
-            raise Exception("A passphrase for SSH key is required")
+            raise Exception("A passphrase for SSH key is required") from exc
     else:
       self.pkey = None
       if self.password is None:

--- a/src/rmview/screenstream/vnc.py
+++ b/src/rmview/screenstream/vnc.py
@@ -190,28 +190,30 @@ class VncStreamer(QRunnable):
 
   def _get_ssh_tunnel(self):
       open_tunnel_kwargs = {
-        "ssh_username" : self.ssh_config.get("username", "root"),
+          "ssh_username": self.ssh_config.get("username", "root"),
       }
 
       if self.ssh_config.get("auth_method", "password") == "key":
           open_tunnel_kwargs["ssh_pkey"] = self.ssh_config["key"]
 
           if self.ssh_config.get("password", None):
-            open_tunnel_kwargs["ssh_private_key_password"] = self.ssh_config["password"]
+              open_tunnel_kwargs["ssh_private_key_password"] = self.ssh_config["password"]
       else:
-        open_tunnel_kwargs["ssh_password"] = self.ssh_config["password"]
+          open_tunnel_kwargs["ssh_password"] = self.ssh_config["password"]
 
       try:
-        import sshtunnel
-      except ModuleNotFoundError:
-        raise Exception("You need to install `sshtunnel` to use the tunnel feature")
+          import sshtunnel
+      except ModuleNotFoundError as exc:
+          raise Exception("You need to install `sshtunnel` to use the tunnel feature") from exc
+
       tunnel = sshtunnel.open_tunnel(
-        (self.ssh.hostname, 22),
-        remote_bind_address=("127.0.0.1", 5900),
-        # We don't specify port so library auto assigns random unused one in the high range
-        local_bind_address=('127.0.0.1',),
-        compression=self.ssh_config.get("tunnel_compression", False),
-        **open_tunnel_kwargs)
+          (self.ssh.hostname, 22),
+          remote_bind_address=("127.0.0.1", 5900),
+          # We don't specify port so library auto assigns random unused one in the high range
+          local_bind_address=('127.0.0.1',),
+          compression=self.ssh_config.get("tunnel_compression", False),
+          **open_tunnel_kwargs
+      )
 
       return tunnel
 


### PR DESCRIPTION
### Changes Made:

- Applied automated fixes for the pylint warning `raise-missing-from`.
"Python's exception chaining shows the traceback of the current exception, but also of the original exception. When you raise a new exception after another exception was caught it's likely that the second exception is a friendly re-wrapping of the first exception. In such cases `raise from` provides a better link between the two tracebacks in the final error. See [https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html](https://pylint.readthedocs.io/en/stable/user_guide/messages/warning/raise-missing-from.html)"

### Note:

This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.