### PR TITLE
fix: unable to ./docker-run.sh on Wayland

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -6,6 +6,7 @@ mkdir -p $CONFIG_DIR
 xhost local:root
 docker build -t rmview .
 docker run \
+  --env XDG_SESSION_TYPE=x11 \
   --env DISPLAY=$DISPLAY \
   --network host \
   --volume $CONFIG_DIR:/root/.config \


### PR DESCRIPTION
The docker-run.sh command forwards the X11 sockets, but since all the environment variables say it's running on Wayland, the Qt platform runs expecting to be able to access it. As it can't, it errors out.

This patch overrides the XDG_SESSION_TYPE environment variable to x11, forcing xwayland usage on Wayland systems while keeping compatibility with x11.

Fixes https://github.com/bordaigorl/rmview/issues/160