### PR TITLE
added deb archive to sources.list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && apt-get install -y \
   libxcb-image0 \
   libxkbcommon-x11-0 \
   && apt-get clean
-RUN apt-get clean
 WORKDIR /rmview
 COPY resources.qrc setup.cfg setup.py ./
 COPY assets ./assets

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM python:3.9-slim-buster
-RUN apt-get update
-RUN apt-get install -y \
+RUN sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list \
+    && sed -i 's|security.debian.org|archive.debian.org|g' /etc/apt/sources.list \
+    && echo "Acquire::Check-Valid-Until false;" > /etc/apt/apt.conf.d/99no-check-valid-until
+RUN apt-get update && apt-get install -y \
   libdbus-1-3 \
   libfontconfig \
   libgl1-mesa-glx \
   libglib2.0-0 \
   libxcb-icccm4 \
   libxcb-image0 \
-  libxkbcommon-x11-0
+  libxkbcommon-x11-0 \
+  && apt-get clean
 RUN apt-get clean
 WORKDIR /rmview
 COPY resources.qrc setup.cfg setup.py ./


### PR DESCRIPTION
docker container build were failing, because Debian "buster" (Debian 10) repositories have been removed from the regular mirror network.